### PR TITLE
Add log4j2 config file to prevent Mixins from using Minecraft's

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ targetCompatibility = 1.8
 
 group = 'net.fabricmc'
 archivesBaseName = project.name
-version = '0.3.1'
+version = '0.3.2'
 
 def ENV = System.getenv()
 if (ENV.BUILD_NUMBER) {

--- a/src/main/resources/log4j2-test.xml
+++ b/src/main/resources/log4j2-test.xml
@@ -8,7 +8,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="info">
+    <Root level="warn">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>

--- a/src/main/resources/log4j2-test.xml
+++ b/src/main/resources/log4j2-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <!-- This is named log4j2-test.xml because -test has higher priority than the normal file that we
+  will pull into the javac classpath via the Minecraft.jar dependency. -->
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
Adds a log4j2 config file that has higher precendence than the one found in the Minecraft jar