### PR TITLE
Catch ClassNotFoundException in MixinMappingProviderTiny (fixes Loom issue 368)

### DIFF
--- a/src/main/java/net/fabricmc/loom/mixin/MixinMappingProviderTiny.java
+++ b/src/main/java/net/fabricmc/loom/mixin/MixinMappingProviderTiny.java
@@ -52,12 +52,12 @@ public class MixinMappingProviderTiny extends MappingProvider {
 			return mapped;
 
 		try {
-			Class c = this.getClass().getClassLoader().loadClass(method.getOwner().replace('/', '.'));
+			final Class<?> c = this.loadClassOrNull(method.getOwner().replace('/', '.'));
 			if (c == null || c == Object.class) {
 				return null;
 			}
 
-			for (Class cc : c.getInterfaces()) {
+			for (Class<?> cc : c.getInterfaces()) {
 				mapped = getMethodMapping(method.move(cc.getName().replace('.', '/')));
 				if (mapped != null) {
 					mapped = mapped.move(classMap.getOrDefault(method.getOwner(), method.getOwner()));
@@ -137,6 +137,14 @@ public class MixinMappingProviderTiny extends MappingProvider {
 			for (MethodDef method : cls.getMethods()) {
 				methodMap.put(new MappingMethod(fromClass, method.getName(from), method.getDescriptor(from)), new MappingMethod(toClass, method.getName(to), method.getDescriptor(to)));
 			}
+		}
+	}
+
+	private Class<?> loadClassOrNull(final String className) {
+		try {
+			return this.getClass().getClassLoader().loadClass(className);
+		} catch (final ClassNotFoundException ex) {
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/FabricMC/fabric-loom/issues/368

As discussed in Discord, it should be fine to return null here if we aren't able to load a class. This doesn't change any behavior (null was already being returned), just removes the stacktrace that is present on compile when soft implementing interfaces.