### PR TITLE
Fix Mixin missing class-change-only refmap entries when the mappings don't include no-op (1:1) name mappings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ targetCompatibility = 1.8
 
 group = 'net.fabricmc'
 archivesBaseName = project.name
-version = '0.4.1'
+version = '0.4.2'
 
 def ENV = System.getenv()
 version = version + (ENV.GITHUB_ACTIONS ? "" : "+local")


### PR DESCRIPTION
The current implementation depends on useless mapping entries such as
```
METHOD	bvx	()V	close	close
```
to properly remap a reference like
```
Lnet/minecraft/server/world/ServerWorld;close()V
```
to
```
Lnet/minecraft/class_3218;close()V
```
and create the appropriate refmap entry.

This PR changes mapping lookup logic to remap the owner if there's no direct member mapping. Mixin used to do the same before 93dca4fc57b5786e915ddf15e88b109a72a63ab1 with that commit apparently being a faulty workaround for a different issue.