### PR TITLE
Use recursive lookup for fields as well to resolve subclass.fieldname references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ targetCompatibility = 1.8
 
 group = 'net.fabricmc'
 archivesBaseName = project.name
-version = '0.4.3'
+version = '0.4.4'
 
 def ENV = System.getenv()
 version = version + (ENV.GITHUB_ACTIONS ? "" : "+local")


### PR DESCRIPTION
This should properly translate e.g. `Lnet/minecraft/entity/LivingEntity;fallDistance:F` where only `Lnet/minecraft/entity/Entity;fallDistance:F` is mapped