### PR TITLE
Handle MappingProvider's guava maps being repackaged.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ targetCompatibility = 1.8
 
 group = 'net.fabricmc'
 archivesBaseName = project.name
-version = '0.4.4'
+version = '0.4.5'
 
 def ENV = System.getenv()
 version = version + (ENV.GITHUB_ACTIONS ? "" : "+local")

--- a/src/main/java/net/fabricmc/loom/mixin/ObfuscationServiceFabric.java
+++ b/src/main/java/net/fabricmc/loom/mixin/ObfuscationServiceFabric.java
@@ -24,12 +24,14 @@
 
 package net.fabricmc.loom.mixin;
 
-import com.google.common.collect.ImmutableSet;
 import org.spongepowered.tools.obfuscation.interfaces.IMixinAnnotationProcessor;
 import org.spongepowered.tools.obfuscation.service.IObfuscationService;
 import org.spongepowered.tools.obfuscation.service.ObfuscationTypeDescriptor;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 public class ObfuscationServiceFabric implements IObfuscationService {
@@ -51,22 +53,22 @@ public class ObfuscationServiceFabric implements IObfuscationService {
 		);
 	}
 
-	private void addSupportedOptions(ImmutableSet.Builder<String> builder, String from, String to) {
-		builder.add(asSuffixed(ObfuscationServiceFabric.IN_MAP_FILE, from, to));
-		builder.add(asSuffixed(ObfuscationServiceFabric.IN_MAP_EXTRA_FILES, from, to));
-		builder.add(asSuffixed(ObfuscationServiceFabric.OUT_MAP_FILE, from, to));
+	private void addSupportedOptions(Set<String> options, String from, String to) {
+		options.add(asSuffixed(ObfuscationServiceFabric.IN_MAP_FILE, from, to));
+		options.add(asSuffixed(ObfuscationServiceFabric.IN_MAP_EXTRA_FILES, from, to));
+		options.add(asSuffixed(ObfuscationServiceFabric.OUT_MAP_FILE, from, to));
 	}
 
 	@Override
 	public Set<String> getSupportedOptions() {
-		ImmutableSet.Builder<String> builder = new ImmutableSet.Builder<>();
-		addSupportedOptions(builder, "official", "intermediary");
-		addSupportedOptions(builder, "official", "named");
-		addSupportedOptions(builder, "intermediary", "official");
-		addSupportedOptions(builder, "intermediary", "named");
-		addSupportedOptions(builder, "named", "official");
-		addSupportedOptions(builder, "named", "intermediary");
-		return builder.build();
+		Set<String> options = new HashSet<>();
+		addSupportedOptions(options, "official", "intermediary");
+		addSupportedOptions(options, "official", "named");
+		addSupportedOptions(options, "intermediary", "official");
+		addSupportedOptions(options, "intermediary", "named");
+		addSupportedOptions(options, "named", "official");
+		addSupportedOptions(options, "named", "intermediary");
+		return Collections.unmodifiableSet(options);
 	}
 
 	@Override
@@ -76,7 +78,7 @@ public class ObfuscationServiceFabric implements IObfuscationService {
 
 	// Hook preserved for Mixin 0.7 backward compatibility
 	public Collection<ObfuscationTypeDescriptor> getObfuscationTypes() {
-		return ImmutableSet.of(
+		return Arrays.asList(
 				createObfuscationType("official", "intermediary"),
 				createObfuscationType("official", "named"),
 				createObfuscationType("intermediary", "official"),


### PR DESCRIPTION
- Handle MappingProvider's guava maps being repackaged.
- Remove guava usage in ObfuscationServiceFabric


Tested quickly with 0.12 loader and loom 0.9.