### PR TITLE
Use the AP environment source model for inheritance lookup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,8 @@ dependencies {
 	implementation ('net.fabricmc:sponge-mixin:0.11.4+mixin.0.8.5') {
 		transitive = false
 	}
-	implementation 'org.ow2.asm:asm:9.3'
+	implementation "org.ow2.asm:asm-tree:$asmVersion"
+	implementation "org.ow2.asm:asm:$asmVersion"
 }
 
 spotless {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 name = fabric-mixin-compile-extensions
 description = Extensions for the Mixin annotation processor
 url = https://github.com/FabricMC/fabric-mixin-compile-extensions
+
+asmVersion=9.4

--- a/src/main/java/net/fabricmc/loom/mixin/MixinMappingProviderTiny.java
+++ b/src/main/java/net/fabricmc/loom/mixin/MixinMappingProviderTiny.java
@@ -28,19 +28,16 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
-import java.net.URL;
 import java.util.Map;
 
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 
-import org.objectweb.asm.ClassReader;
 import org.spongepowered.asm.obfuscation.mapping.IMapping;
 import org.spongepowered.asm.obfuscation.mapping.common.MappingField;
 import org.spongepowered.asm.obfuscation.mapping.common.MappingMethod;
+import org.spongepowered.tools.obfuscation.interfaces.ITypeHandleProvider;
 import org.spongepowered.tools.obfuscation.mapping.common.MappingProvider;
 import org.spongepowered.tools.obfuscation.mapping.fg3.MappingMethodLazy;
 
@@ -48,7 +45,10 @@ import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
+import org.spongepowered.tools.obfuscation.mirror.TypeHandle;
+
 public class MixinMappingProviderTiny extends MappingProvider {
+	private final ITypeHandleProvider types;
 	private final String from, to;
 
 	// Done to account for MappingProvider's maps being from guava, and shaded.
@@ -56,10 +56,9 @@ public class MixinMappingProviderTiny extends MappingProvider {
 	protected final Map<MappingField, MappingField> fieldMap = getMap("fieldMap");
 	protected final Map<MappingMethod, MappingMethod> methodMap = getMap("methodMap");
 
-	private final ClassLoader classLoader = getClass().getClassLoader();
-
-	public MixinMappingProviderTiny(Messager messager, Filer filer, String from, String to) {
+	public MixinMappingProviderTiny(Messager messager, Filer filer, ITypeHandleProvider types, String from, String to) {
 		super(messager, filer);
+		this.types = types;
 		this.from = from;
 		this.to = to;
 	}
@@ -123,18 +122,18 @@ public class MixinMappingProviderTiny extends MappingProvider {
 		if (member.getOwner() == null) return null;
 
 		try {
-			final ClassReader c = this.loadClassOrNull(member.getOwner());
+			final TypeHandle c = this.loadClassOrNull(member.getOwner());
 
 			if (c == null) {
 				return null;
 			}
 
-			if ("java/lang/Object".equals(c.getClassName())) {
+			if ("java/lang/Object".equals(c.getName())) {
 				return null;
 			}
 
-			for (String iface : c.getInterfaces()) {
-				mapped = getMapping0(member.move(iface), map);
+			for (TypeHandle iface : c.getInterfaces()) {
+				mapped = getMapping0(member.move(iface.getName()), map);
 
 				if (mapped != null) {
 					mapped = mapped.move(classMap.getOrDefault(member.getOwner(), member.getOwner()));
@@ -143,8 +142,9 @@ public class MixinMappingProviderTiny extends MappingProvider {
 				}
 			}
 
-			if (c.getSuperName() != null) {
-				mapped = getMapping0(member.move(c.getSuperName()), map);
+			final TypeHandle superType = c.getSuperclass();
+			if (superType != null) {
+				mapped = getMapping0(member.move(superType.getName()), map);
 
 				if (mapped != null) {
 					mapped = mapped.move(classMap.getOrDefault(member.getOwner(), member.getOwner()));
@@ -185,26 +185,8 @@ public class MixinMappingProviderTiny extends MappingProvider {
 		}
 	}
 
-	private ClassReader loadClassOrNull(final String className) {
-		String classFileName = getClassFileName(className);
-
-		// Use getResource instead of getResourceAsStream to work around https://bugs.openjdk.java.net/browse/JDK-8205976 :)
-		URL resource = classLoader.getResource(classFileName);
-
-		if (resource == null) {
-			// Class not found.
-			return null;
-		}
-
-		try (InputStream is = resource.openStream()) {
-			return new ClassReader(is);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Failed to read class " + className, e);
-		}
-	}
-
-	public String getClassFileName(String className) {
-		return className.replace('.', '/').concat(".class");
+	private TypeHandle loadClassOrNull(final String className) {
+		return this.types.getTypeHandle(className);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/net/fabricmc/loom/mixin/MixinMappingProviderTiny.java
+++ b/src/main/java/net/fabricmc/loom/mixin/MixinMappingProviderTiny.java
@@ -40,12 +40,11 @@ import org.spongepowered.asm.obfuscation.mapping.common.MappingMethod;
 import org.spongepowered.tools.obfuscation.interfaces.ITypeHandleProvider;
 import org.spongepowered.tools.obfuscation.mapping.common.MappingProvider;
 import org.spongepowered.tools.obfuscation.mapping.fg3.MappingMethodLazy;
+import org.spongepowered.tools.obfuscation.mirror.TypeHandle;
 
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
-
-import org.spongepowered.tools.obfuscation.mirror.TypeHandle;
 
 public class MixinMappingProviderTiny extends MappingProvider {
 	private final ITypeHandleProvider types;
@@ -143,6 +142,7 @@ public class MixinMappingProviderTiny extends MappingProvider {
 			}
 
 			final TypeHandle superType = c.getSuperclass();
+
 			if (superType != null) {
 				mapped = getMapping0(member.move(superType.getName()), map);
 

--- a/src/main/java/net/fabricmc/loom/mixin/ObfuscationEnvironmentFabric.java
+++ b/src/main/java/net/fabricmc/loom/mixin/ObfuscationEnvironmentFabric.java
@@ -40,7 +40,7 @@ public class ObfuscationEnvironmentFabric extends ObfuscationEnvironment {
 	@Override
 	protected IMappingProvider getMappingProvider(Messager messager, Filer filer) {
 		String[] key = type.getKey().split(":");
-		return new MixinMappingProviderTiny(messager, filer, key[0], key[1]);
+		return new MixinMappingProviderTiny(messager, filer, this.ap.getTypeProvider(), key[0], key[1]);
 	}
 
 	@Override


### PR DESCRIPTION
🎶 *she's just a bytecode girl, living in a source model world* 🎶

This saves us from having to put the entire compile classpath on the compiler's AP path, potentially helping to resolve FabricMC/fabric-loom#813. See the upcoming comment on that PR for a discussion of the underlying issues resolved.

I've added in extra ASM deps since the removal of the compile classpath has meant that Mixin doesn't get those deps by luck-of-classpath. Just asm and -tree seem to be enough for the AP, in my testing at least.